### PR TITLE
Update Maven and Docker dependencies to latest versions

### DIFF
--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: postgres:17.7
+    image: postgres:17.10
     container_name: postgres
     ports:
       - 5432:5432
@@ -15,7 +15,7 @@ services:
       retries: 5
 
   qdrant:
-    image: docker.io/qdrant/qdrant:v1.16.3
+    image: docker.io/qdrant/qdrant:v1.18.2
     container_name: qdrant
     ports:
       - 6333:6333
@@ -24,7 +24,7 @@ services:
       - .qdrant:/qdrant/storage:z
 
   redis:
-    image: redis:8.4.0-alpine
+    image: redis:8.8.0-alpine
     container_name: redis
     hostname: redis
     ports:

--- a/infrastructure/docker/postgresql.yml
+++ b/infrastructure/docker/postgresql.yml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: postgres:17.7
+    image: postgres:17.10
     container_name: postgres
     ports:
       - 5432:5432

--- a/infrastructure/docker/qdrant.yml
+++ b/infrastructure/docker/qdrant.yml
@@ -1,6 +1,6 @@
 services:
   qdrant:
-    image: docker.io/qdrant/qdrant:v1.16.3
+    image: docker.io/qdrant/qdrant:v1.18.2
     container_name: qdrant
     ports:
       - 6333:6333

--- a/infrastructure/docker/redis.yml
+++ b/infrastructure/docker/redis.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.4.0-alpine
+    image: redis:8.8.0-alpine
     container_name: redis
     hostname: redis
     ports:

--- a/mcp-currency/pom.xml
+++ b/mcp-currency/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <!-- MCP Server -->
-    <mcp.server.version>1.11.0</mcp.server.version>
+    <mcp.server.version>1.13.0</mcp.server.version>
     <!-- Project -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.34.1</quarkus.platform.version>
-    <quarkus.renarde.version>3.1.6</quarkus.renarde.version>
+    <quarkus.platform.version>3.36.2</quarkus.platform.version>
+    <quarkus.renarde.version>3.1.7</quarkus.renarde.version>
     <!-- Web -->
     <!-- https://mvnrepository.com/artifact/org.mvnpm/bootstrap -->
     <bootstrap.version>5.3.8</bootstrap.version>
@@ -28,13 +28,13 @@
     <bootstrap-icons.version>1.13.1</bootstrap-icons.version>
     <!-- LangChain4j -->
     <!-- https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-bom -->
-    <langchain4j.version>1.12.2</langchain4j.version>
+    <langchain4j.version>1.16.3</langchain4j.version>
     <!-- https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-community-bom -->
-    <langchain4j-community.version>1.12.2-beta22</langchain4j-community.version>
+    <langchain4j-community.version>1.16.0-beta26</langchain4j-community.version>
     <tinylog.version>2.7.0</tinylog.version>
     <!-- Plugins -->
     <compiler-plugin.version>3.15.0</compiler-plugin.version>
-    <surefire-plugin.version>3.5.5</surefire-plugin.version>
+    <surefire-plugin.version>3.5.6</surefire-plugin.version>
     <exec-plugin.version>3.6.3</exec-plugin.version>
     <maven.compiler.release>21</maven.compiler.release>
     <skipITs>true</skipITs>

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -45,14 +45,14 @@ All public methods across controllers and resources have comprehensive entry log
 
 ## Architecture Overview
 
-This is a **Quarkus 3.24.5** vintage store application that demonstrates AI-powered e-commerce with sophisticated chat capabilities.
+This is a **Quarkus 3.36.2** vintage store application that demonstrates AI-powered e-commerce with sophisticated chat capabilities.
 
 ### Core Technology Stack
-- **Quarkus Renarde 3.1.1** - Web framework with type-safe Qute templating
-- **LangChain4j 1.1.0** - AI integration with Anthropic Claude Sonnet 4 and RAG capabilities
+- **Quarkus Renarde 3.1.7** - Web framework with type-safe Qute templating
+- **LangChain4j 1.16.3** - AI integration with Anthropic Claude Sonnet 4 and RAG capabilities
 - **Hibernate ORM with Panache** - Simplified data persistence
-- **PostgreSQL 17.5** - Production database with comprehensive test data
-- **Bootstrap 5.3.7** - Frontend UI framework with WebSocket chat integration
+- **PostgreSQL 17.10** - Production database with comprehensive test data
+- **Bootstrap 5.3.8** - Frontend UI framework with WebSocket chat integration
 
 ### AI/RAG System Architecture
 The application features a sophisticated **Retrieval Augmented Generation (RAG)** system:


### PR DESCRIPTION
Bumps all project dependencies to their latest stable versions to pick up bug fixes, performance improvements, and new features.

## Maven dependencies

| Dependency | From | To |
|---|---|---|
| Quarkus Platform | 3.34.1 | 3.36.2 |
| Quarkus Renarde | 3.1.6 | 3.1.7 |
| LangChain4j | 1.12.2 | 1.16.3 |
| LangChain4j Community BOM | 1.12.2-beta22 | 1.16.0-beta26 |
| Maven Surefire Plugin | 3.5.5 | 3.5.6 |
| Quarkus MCP Server | 1.11.0 | 1.13.0 |

## Docker images

| Image | From | To |
|---|---|---|
| PostgreSQL | 17.7 | 17.10 |
| Qdrant | v1.16.3 | v1.18.2 |
| Redis | 8.4.0-alpine | 8.8.0-alpine |

## Notes

- PostgreSQL stays on the 17.x line to avoid a major version upgrade.
- Bootstrap (5.3.8), Bootstrap Icons (1.13.1), Tinylog (2.7.0), Compiler Plugin (3.15.0), and Exec Plugin (3.6.3) were already at their latest stable versions.
- Build compiles and all tests pass.